### PR TITLE
Fix gemspec to include .json

### DIFF
--- a/plu.gemspec
+++ b/plu.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |spec|
   spec.author        = "Andrew Kane"
   spec.email         = "andrew@ankane.org"
 
-  spec.files         = Dir["*.{md,txt,csv}", "{lib}/**/*"]
+  spec.files         = Dir["*.{md,txt,csv,json}", "{lib}/**/*"]
   spec.require_path  = "lib"
 
   spec.required_ruby_version = ">= 3.1"


### PR DESCRIPTION
The `plu_codes.json` is not included in the gem right now, so it doesn't work when installed from RubyGems.